### PR TITLE
Add python37

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
     libmemcached-dev \
     python3-distutils \
     python3-pip \
-    python37 \
+    python3.7 \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/* \
     && rm /usr/bin/python3 && ln -s /usr/bin/python3.7 /usr/bin/python3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ LABEL maintainer "YunoJuno <code@yunojuno.com>"
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
+# Add deadsnakes PPA to get latest version of python
+RUN apt-get update \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa
+
 # install minimal deps required to build pylibmc and update Python3
 RUN apt-get update && apt-get install -y \
     gettext \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,17 @@ LABEL maintainer "YunoJuno <code@yunojuno.com>"
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
-# install minimal deps required to build pylibmc
+# install minimal deps required to build pylibmc and update Python3
 RUN apt-get update && apt-get install -y \
     gettext \
     libmemcached-dev \
     python3-distutils \
     python3-pip \
+    python37 \
     zlib1g-dev \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && rm /usr/bin/python3 && ln -s /usr/bin/python3.7 /usr/bin/python3 \
+    && python3 --version
 
 # install pipenv
 RUN set -ex && pip3 install pipenv


### PR DESCRIPTION
The default Py3 version on the image is 3.6, so we need to explicitly add python37,
and then update the symlinks so that `python3` points to the correct version.